### PR TITLE
Fix SSA managed-fields type converter for scanner group

### DIFF
--- a/apis/trivy/openapi_generated.go
+++ b/apis/trivy/openapi_generated.go
@@ -20887,16 +20887,8 @@ func schema_kubeopsdev_scanner_apis_trivy_Time(ref common.ReferenceCallback) com
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Type: []string{"object"},
-				Properties: map[string]spec.Schema{
-					"Time": {
-						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "date-time",
-						},
-					},
-				},
-				Required: []string{"Time"},
+				Type:   Time{}.OpenAPISchemaType(),
+				Format: Time{}.OpenAPISchemaFormat(),
 			},
 		},
 	}

--- a/apis/trivy/time.go
+++ b/apis/trivy/time.go
@@ -79,6 +79,14 @@ func (t Time) MarshalJSON() ([]byte, error) {
 	return buf, nil
 }
 
+// OpenAPISchemaType and OpenAPISchemaFormat mirror metav1.Time so openapi-gen
+// emits a scalar date-time string. Without them, defining Time as a new named
+// type strips metav1.Time's methods and the generated schema becomes an object,
+// breaking the server-side-apply type converter.
+func (Time) OpenAPISchemaType() []string { return []string{"string"} }
+
+func (Time) OpenAPISchemaFormat() string { return "date-time" }
+
 func init() {
 	utilruntime.Must(
 		apiequality.Semantic.AddFunc(func(a, b Time) bool {

--- a/pkg/cmds/server/start.go
+++ b/pkg/cmds/server/start.go
@@ -117,7 +117,11 @@ func (o *ScannerServerOptions) Config() (*apiserver.Config, error) {
 		openapi.NewDefinitionNamer(apiserver.Scheme))
 	serverConfig.OpenAPIV3Config.Info.Title = "scanner"
 	serverConfig.OpenAPIV3Config.Info.Version = api.SchemeGroupVersion.Version
-	serverConfig.OpenAPIV3Config.IgnorePrefixes = ignore
+	// Do NOT reuse `ignore` here: the v3 config feeds the server-side-apply
+	// managed-fields type converter (getOpenAPIModels), and ignoring the scanner
+	// group prefix drops its resources from the converter, causing
+	// "no corresponding type for scanner.appscode.com/v1alpha1" on every write.
+	serverConfig.OpenAPIV3Config.IgnorePrefixes = []string{"/swaggerapi"}
 
 	extraConfig := apiserver.ExtraConfig{
 		ClientConfig:         serverConfig.ClientConfig,


### PR DESCRIPTION
## Problem

Every write to a `scanner.appscode.com/v1alpha1` object logs:

```
[SHOULD NOT HAPPEN] failed to update managedFields ... no corresponding type for
scanner.appscode.com/v1alpha1, Kind=ImageScanRequest
```

and `metadata.managedFields` is never populated.

## Root cause

`start.go` built one `ignore` list for the OpenAPI **v2** config — which excludes the scanner group prefix `/apis/scanner.appscode.com/v1alpha1` — and then **reused** it for `OpenAPIV3Config`.

Server-side apply (GA) builds its managed-fields type converter from the **v3** config: `GenericAPIServer.getOpenAPIModels` → `getResourceNamesForGroup` skips any resource whose path is under an `IgnorePrefixes` entry. Since `api.SchemeGroupVersion.String()` is `scanner.appscode.com/v1alpha1`, that prefix matches **every** scanner resource, so all of them are dropped from the converter's GVK→schema map → `no corresponding type` on every write.

## Fix

Give the v3 config its own `IgnorePrefixes = []string{"/swaggerapi"}` instead of reusing the v2 `ignore` list. The scanner resources now reach the converter; the v2 published-spec behavior is unchanged.

## Verification

`go build ./...` green. On a cluster running this build, an `Update`/`Apply` populates `metadata.managedFields` and the `[SHOULD NOT HAPPEN]` line is gone.