### PR TITLE
Modernize golangci-lint config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,27 +2,22 @@ version: "2"
 linters:
   default: standard
   enable:
+    - bodyclose
+    - prealloc
     - unparam
+  exclusions:
+    paths:
+      - generated.*\.go
+      - client
+      - vendor
 
 formatters:
   enable:
-    - gofmt
+    - gofumpt
     - goimports
-  settings:
-    gofmt:
-      rewrite-rules:
-        - pattern: 'interface{}'
-          replacement: 'any'
 
 issues:
   max-same-issues: 100
-
-  exclude-files:
-    - generated.*\\.go
-
-  exclude-dirs:
-    - client
-    - vendor
 
 run:
   timeout: 10m

--- a/apis/reports/v1alpha1/register.go
+++ b/apis/reports/v1alpha1/register.go
@@ -48,14 +48,16 @@ func Resource(resource string) schema.GroupResource {
 
 // Adds the list of known types to api.Scheme.
 func addKnownTypes(scheme *runtime.Scheme) error {
-	scheme.AddKnownTypes(SchemeGroupVersion,
+	scheme.AddKnownTypes(
+		SchemeGroupVersion,
 		&CVEReport{},
 		&Image{},
 		&Workload{},
 		&WorkloadList{},
 	)
 
-	scheme.AddKnownTypes(SchemeGroupVersion,
+	scheme.AddKnownTypes(
+		SchemeGroupVersion,
 		&metav1.Status{},
 	)
 	metav1.AddToGroupVersion(scheme, SchemeGroupVersion)

--- a/apis/scanner/register.go
+++ b/apis/scanner/register.go
@@ -46,7 +46,8 @@ var (
 
 // Adds the list of known types to the given scheme.
 func addKnownTypes(scheme *runtime.Scheme) error {
-	scheme.AddKnownTypes(SchemeGroupVersion,
+	scheme.AddKnownTypes(
+		SchemeGroupVersion,
 		&ImageScanRequest{},
 		&ImageScanRequestList{},
 		&ImageScanReport{},

--- a/apis/scanner/v1alpha1/register.go
+++ b/apis/scanner/v1alpha1/register.go
@@ -48,7 +48,8 @@ func Resource(resource string) schema.GroupResource {
 
 // Adds the list of known types to api.Scheme.
 func addKnownTypes(scheme *runtime.Scheme) error {
-	scheme.AddKnownTypes(SchemeGroupVersion,
+	scheme.AddKnownTypes(
+		SchemeGroupVersion,
 		&ImageScanRequest{},
 		&ImageScanRequestList{},
 		&ImageScanReport{},
@@ -57,7 +58,8 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 		&VulnerabilityList{},
 	)
 
-	scheme.AddKnownTypes(SchemeGroupVersion,
+	scheme.AddKnownTypes(
+		SchemeGroupVersion,
 		&metav1.Status{},
 	)
 	metav1.AddToGroupVersion(scheme, SchemeGroupVersion)

--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -79,7 +79,8 @@ func init() {
 
 	// TODO: keep the generic API server from wanting this
 	unversioned := schema.GroupVersion{Group: "", Version: "v1"}
-	Scheme.AddUnversionedTypes(unversioned,
+	Scheme.AddUnversionedTypes(
+		unversioned,
 		&metav1.Status{},
 		&metav1.APIVersions{},
 		&metav1.APIGroupList{},
@@ -118,7 +119,8 @@ func (c ExtraConfig) LicenseProvided() bool {
 	ok, _ := discovery.HasGVK(
 		c.KubeClient.Discovery(),
 		proxyserver.SchemeGroupVersion.String(),
-		proxyserver.ResourceKindLicenseRequest)
+		proxyserver.ResourceKindLicenseRequest,
+	)
 	return ok
 }
 
@@ -226,7 +228,7 @@ func (c completedConfig) New(ctx context.Context) (*ScannerServer, error) {
 		}
 	}
 
-	if err = (scanrequest.NewImageScanRequestReconciler(
+	if err = scanrequest.NewImageScanRequestReconciler(
 		mgr.GetClient(),
 		nc,
 		c.ExtraConfig.ScannerImage,
@@ -236,7 +238,7 @@ func (c completedConfig) New(ctx context.Context) (*ScannerServer, error) {
 		c.ExtraConfig.FileServerFilesDir,
 		c.ExtraConfig.ScanRequestTTLPeriod,
 		c.ExtraConfig.Workspace,
-	)).SetupWithManager(mgr); err != nil {
+	).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "ImageScanRequest")
 		os.Exit(1)
 	}

--- a/pkg/cmds/server/start.go
+++ b/pkg/cmds/server/start.go
@@ -72,7 +72,7 @@ func (o ScannerServerOptions) AddFlags(fs *pflag.FlagSet) {
 
 // Validate validates ScannerServerOptions
 func (o ScannerServerOptions) Validate(args []string) error {
-	var errors []error
+	errors := make([]error, 0, 2)
 	errors = append(errors, o.RecommendedOptions.Validate()...)
 	errors = append(errors, o.ExtraOptions.Validate()...)
 	return utilerrors.NewAggregate(errors)

--- a/pkg/cmds/server/start.go
+++ b/pkg/cmds/server/start.go
@@ -107,14 +107,16 @@ func (o *ScannerServerOptions) Config() (*apiserver.Config, error) {
 
 	serverConfig.OpenAPIConfig = genericapiserver.DefaultOpenAPIConfig(
 		api.GetOpenAPIDefinitions,
-		openapi.NewDefinitionNamer(apiserver.Scheme))
+		openapi.NewDefinitionNamer(apiserver.Scheme),
+	)
 	serverConfig.OpenAPIConfig.Info.Title = "scanner"
 	serverConfig.OpenAPIConfig.Info.Version = api.SchemeGroupVersion.Version
 	serverConfig.OpenAPIConfig.IgnorePrefixes = ignore
 
 	serverConfig.OpenAPIV3Config = genericapiserver.DefaultOpenAPIV3Config(
 		api.GetOpenAPIDefinitions,
-		openapi.NewDefinitionNamer(apiserver.Scheme))
+		openapi.NewDefinitionNamer(apiserver.Scheme),
+	)
 	serverConfig.OpenAPIV3Config.Info.Title = "scanner"
 	serverConfig.OpenAPIV3Config.Info.Version = api.SchemeGroupVersion.Version
 	serverConfig.OpenAPIV3Config.IgnorePrefixes = ignore


### PR DESCRIPTION
## Summary

Modernize the `.golangci.yml` configuration for golangci-lint v2 and switch the configured formatter to gofumpt.

This aligns the linter with the build image (`ghcr.io/appscode/golang-dev`), where `gofmt` is a shim to gofumpt — so `make fmt` (via `hack/fmt.sh`'s `gofmt -s -w`) and the linter now enforce the same formatting. No change to `hack/fmt.sh` is needed.

### `.golangci.yml`
- Enable **`bodyclose`** and **`prealloc`** linters (`unparam` was already enabled).
- Move `exclude-files` / `exclude-dirs` out of the deprecated `issues:` block into **`linters.exclusions.paths`** — the correct location in golangci-lint v2.
- Fix the over-escaped exclusion regex `generated.*\\.go` → `generated.*\.go`.
- Switch the formatter from **`gofmt` → `gofumpt`** and drop the now-unneeded `interface{}` → `any` rewrite rule (gofumpt performs this itself at go1.18+).

### Resulting formatting
- gofumpt reformatting applied across the affected Go files.
